### PR TITLE
Handle "compositeId" parameter

### DIFF
--- a/src/app/api/schemas/member.schema.json
+++ b/src/app/api/schemas/member.schema.json
@@ -71,6 +71,9 @@
     },
     "incrementSeed": {
       "type": "integer"
+    },
+    "compositeId": {
+      "type": "string"
     }
   },
   "required": [

--- a/src/app/engine/builder.py
+++ b/src/app/engine/builder.py
@@ -4,7 +4,7 @@ from django.conf import settings
 class MemberBuilder:
     STATIC_FIELDS = {"mediaType": "image/jpeg", "family": "I"}
 
-    STRIP_FIELDS = ["@type", "originFormat", "incrementSeed"]
+    STRIP_FIELDS = ["@type", "originFormat", "incrementSeed", "compositeId"]
 
     FORMAT_FIELDS = [
         "id",
@@ -26,7 +26,8 @@ class MemberBuilder:
     def __build_template(self, original_template):
         template = dict(original_template) | self.STATIC_FIELDS
         for strip_field in self.STRIP_FIELDS:
-            template.pop(strip_field)
+            if strip_field in template:
+                template.pop(strip_field)
         return template
 
     def build_member(self, dlcs_uri):

--- a/src/app/engine/s3.py
+++ b/src/app/engine/s3.py
@@ -29,7 +29,9 @@ class S3Client:
     def put_images(self, images, submission_id, composite_id, customer_id, space_id):
         s3_uris = []
 
-        key_prefix = self.__get_key_prefix(submission_id, composite_id, customer_id, space_id)
+        key_prefix = self.__get_key_prefix(
+            submission_id, composite_id, customer_id, space_id
+        )
 
         with tqdm.tqdm(
             desc=f"[{submission_id}] Upload images to S3",

--- a/src/app/engine/s3.py
+++ b/src/app/engine/s3.py
@@ -26,8 +26,10 @@ class S3Client:
         else:
             return f"https://s3.amazonaws.com/{self._bucket_name}"
 
-    def put_images(self, submission_id, images):
+    def put_images(self, images, submission_id, composite_id, customer_id, space_id):
         s3_uris = []
+
+        key_prefix = self.__get_key_prefix(submission_id, composite_id, customer_id, space_id)
 
         with tqdm.tqdm(
             desc=f"[{submission_id}] Upload images to S3",
@@ -39,14 +41,17 @@ class S3Client:
                 # same order as the list of images provided to it. '.map(...)' gives us that,
                 # whilst '.submit(...)' does not.
                 for s3_uri in executor.map(
-                    self.__put_image, repeat(submission_id), images
+                    self.__put_image, repeat(key_prefix), images
                 ):
                     s3_uris.append(s3_uri)
                     progress_bar.update(1)
         return s3_uris
 
-    def __put_image(self, submission_id, image):
-        object_key = f"{self._object_key_prefix}/{submission_id}/{os.path.basename(image.filename)}"
+    def __get_key_prefix(self, submission_id, composite_id, customer, space):
+        return f"{self._object_key_prefix}/{customer}/{space}/{composite_id or submission_id}"
+
+    def __put_image(self, key_prefix, image):
+        object_key = f"{key_prefix}/{os.path.basename(image.filename)}"
         with open(image.filename, "rb") as file:
             self._client.put_object(Bucket=self._bucket_name, Key=object_key, Body=file)
         return f"{self._bucket_base_url}/{object_key}"

--- a/src/app/engine/tasks.py
+++ b/src/app/engine/tasks.py
@@ -57,7 +57,10 @@ def __rasterize_composite(member, pdf_path):
 
 def __push_images_to_dlcs(member, images):
     __update_status(member, "PUSHING_TO_DLCS", image_count=len(images))
-    return s3_client.put_images(member.id, images)
+    composite_id = member.json_data.get("compositeId")
+    customer = member.collection.customer
+    space = member.json_data["space"]
+    return s3_client.put_images(images, member.id, composite_id, customer, space)
 
 
 def __build_dlcs_requests(member, dlcs_uris):


### PR DESCRIPTION
This is the implementation of [DLCS Protagonist RFC-013](https://github.com/dlcs/protagonist/blob/main/docs/rfcs/013-pdfs-as-input-storage.md).

When creating a member there is a new optional `"compositeId"` parameter that can be specified. This is used as part of the s3 key where rasterized images are uploaded to. If not provided the `member.id` value is used. In addition to these values the `/customer/space/` is added to s3 keys.