### PR TITLE
Increase PIL MAX_IMAGE_PIXELS to avoid decompression bomb warnings

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
       - id: end-of-file-fixer
       - id: requirements-txt-fixer
       - id: trailing-whitespace
-  - repo: https://github.com/ambv/black
+  - repo: https://github.com/psf/black
     rev: 23.11.0
     hooks:
       - id: black

--- a/src/app/engine/rasterizers.py
+++ b/src/app/engine/rasterizers.py
@@ -2,9 +2,10 @@ import os
 
 from django.conf import settings
 from pdf2image import convert_from_path
-from PIL import Image 
+from PIL import Image
 
 Image.MAX_IMAGE_PIXELS = 1000000000
+
 
 class PdfRasterizer:
     def __init__(self):

--- a/src/app/engine/rasterizers.py
+++ b/src/app/engine/rasterizers.py
@@ -2,7 +2,9 @@ import os
 
 from django.conf import settings
 from pdf2image import convert_from_path
+from PIL import Image 
 
+Image.MAX_IMAGE_PIXELS = 1000000000
 
 class PdfRasterizer:
     def __init__(self):


### PR DESCRIPTION
See https://github.com/Belval/pdf2image/issues/76 and https://pillow.readthedocs.io/en/stable/reference/Image.html#PIL.Image.MAX_IMAGE_PIXELS.

Was seeing occasional decompression bomb warnings being logged.