### PR TITLE
Close PIL Image after use

### DIFF
--- a/src/app/engine/rasterizers.py
+++ b/src/app/engine/rasterizers.py
@@ -65,6 +65,7 @@ class PdfRasterizer:
             if res == ResizeResult.SINGLE_PIXEL:
                 single_pixel_pages.append(idx + 1)
             idx += 1
+            im.close()
 
         if single_pixel_pages:
             return self.__rescale_single_page_default_dpi(
@@ -89,8 +90,8 @@ class PdfRasterizer:
             logger.info(
                 f"resizing image index {idx} from {w},{h} to {scale_w},{scale_h}"
             )
-            resized = im.resize((scale_w, scale_h), resample=Image.LANCZOS)
-            resized.save(filename)
+            with im.resize((scale_w, scale_h), resample=Image.LANCZOS) as resized:
+                resized.save(filename)
             return ResizeResult.RESIZED
 
         return ResizeResult.NOOP

--- a/src/app/engine/rasterizers.py
+++ b/src/app/engine/rasterizers.py
@@ -33,7 +33,7 @@ class PdfRasterizer:
         pdf_source = os.path.join(subfolder_path, "source.pdf")
         images = self.__rasterize(pdf_source, subfolder_path, dpi=self._dpi)
         images = self.__validate_rasterized_images(images, pdf_source, subfolder_path)
-        return images
+        return [i.filename for i in images]
 
     def __rasterize(
         self, pdf_source, subfolder_path, start_page=None, last_page=None, dpi=None

--- a/src/app/engine/tasks.py
+++ b/src/app/engine/tasks.py
@@ -28,8 +28,8 @@ def process_member(args):
     folder_path = None
     try:
         folder_path = __fetch_origin(member, member.json_data["origin"])
-        images = __rasterize_composite(member, folder_path)
-        s3_urls = __push_images_to_dlcs(member, images)
+        image_paths = __rasterize_composite(member, folder_path)
+        s3_urls = __push_images_to_dlcs(member, image_paths)
         dlcs_requests = __build_dlcs_requests(member, s3_urls)
         dlcs_responses = __initiate_dlcs_ingest(member, dlcs_requests, args["auth"])
         return __build_result(member, dlcs_responses)
@@ -49,12 +49,12 @@ def __rasterize_composite(member, pdf_path):
     return pdf_rasterizer.rasterize_pdf(pdf_path)
 
 
-def __push_images_to_dlcs(member, images):
-    __update_status(member, "PUSHING_TO_DLCS", image_count=len(images))
+def __push_images_to_dlcs(member, image_paths):
+    __update_status(member, "PUSHING_TO_DLCS", image_count=len(image_paths))
     composite_id = member.json_data.get("compositeId")
     customer = member.collection.customer
     space = member.json_data["space"]
-    return s3_client.put_images(images, member.id, composite_id, customer, space)
+    return s3_client.put_images(image_paths, member.id, composite_id, customer, space)
 
 
 def __build_dlcs_requests(member, dlcs_uris):


### PR DESCRIPTION
PDFs that have a lot of images that require resizing can see memory leaks as the PIL image stays in memory (see #42).

Updated `PdfRasterizer` class to close image after use and return the image path only, rather than full `Image` object to avoid future issues with consumer attempting to use a closed image.